### PR TITLE
Switch to Debian Bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG jdk_version="19"
-ARG os_version="alpine3.16"
+ARG jdk_version="22"
+ARG os_version="bookworm"
 
 FROM openjdk:${jdk_version}-jdk-${os_version}
 
@@ -10,17 +10,24 @@ ENV LANG="C.UTF-8"
 COPY local.conf /etc/fonts/
 
 RUN set -eux; \
-    apk add --no-cache \
-            graphviz \
-            wget \
-            ca-certificates \
-            fontconfig \
-            font-noto \
+    apt-get update; \
+    apt-get install --no-install-recommends \
+                    --assume-yes \
+                    --auto-remove \
+                    graphviz \
+                    wget \
+                    ca-certificates \
+                    fontconfig \
+                    fonts-noto \
     && fc-cache --force \
                 --verbose \
     && wget "https://github.com/plantuml/plantuml/releases/download/v${plantuml_version}/plantuml-${plantuml_version}.jar" \
             --output-document plantuml.jar \
-    && apk del wget
+    && apt-get purge --assume-yes \
+                     wget \
+    && apt-get autoremove \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists
 
 ENTRYPOINT ["java", "-jar", "plantuml.jar", "-pipe"]
 CMD ["-tsvg"]


### PR DESCRIPTION
Unfortunately PlantUML stopped providing Docker images based on Alpine. Existing images don't play well with Apple ARM chips. So I decided to switch to Debian.

Debian-based images are still officialy coming from PlantUML team. Therefore, it should be safe to rely on them.